### PR TITLE
fix: handle rgb/rgba color picker values in frontend CSS output

### DIFF
--- a/bb-bootstrap-alerts-module/includes/frontend.css.php
+++ b/bb-bootstrap-alerts-module/includes/frontend.css.php
@@ -1,3 +1,36 @@
+<?php
+/**
+ * Format a Beaver Builder color value for CSS output.
+ *
+ * The Beaver Builder color picker stores values as bare hex (e.g. "e92525"),
+ * but also as rgb()/rgba() strings when a color is not fully opaque. Hard-coding
+ * a "#" prefix produces invalid CSS such as "#rgb(233, 37, 37)", which browsers
+ * silently discard. This helper handles all four cases.
+ *
+ * @since 1.2.7
+ *
+ * @param string $color   Raw color value from the picker.
+ * @param string $default Optional fallback color value.
+ * @return string Formatted, CSS-safe color value.
+ */
+if ( ! function_exists( 'bb_alerts_format_color' ) ) {
+	function bb_alerts_format_color( $color, $default = '' ) {
+		if ( empty( $color ) ) {
+			return $default ? bb_alerts_format_color( $default ) : '';
+		}
+		// rgb()/rgba() values are already valid CSS.
+		if ( 0 === strpos( $color, 'rgb' ) ) {
+			return $color;
+		}
+		// Hex value that already includes the "#" prefix.
+		if ( 0 === strpos( $color, '#' ) ) {
+			return $color;
+		}
+		// Bare hex without a "#" prefix.
+		return '#' . $color;
+	}
+}
+?>
 /* typography */
 .fl-node-<?php echo $id; ?> {
 <?php if( is_array( $settings->bbn_font_field ) && ( ( $settings->bbn_font_field['family'] ) != 'Default' ) ): ?>
@@ -19,9 +52,9 @@
 
 /* custom notification type field css */
 .fl-node-<?php echo $id; ?> .alert-custom {
-	color: #<?php echo $settings->bbn_font_color; ?>;
-	background-color: #<?php echo $settings->bbn_background_color; ?>;
-	border-color: #<?php echo $settings->bbn_border_color; ?>;
+	color: <?php echo bb_alerts_format_color( $settings->bbn_font_color ); ?>;
+	background-color: <?php echo bb_alerts_format_color( $settings->bbn_background_color ); ?>;
+	border-color: <?php echo bb_alerts_format_color( $settings->bbn_border_color ); ?>;
 	border-width:<?php echo ($settings->bbn_border_size != '') ? $settings->bbn_border_size : '1' ?>px;
 	border-style:<?php echo $settings->bbn_border_style; ?>;
 	border-radius:<?php echo ($settings->bbn_border_radius != '') ? $settings->bbn_border_radius : '4' ?>px;
@@ -33,7 +66,7 @@
 .fl-node-<?php echo $id; ?> .fa,
 .fl-node-<?php echo $id; ?> .ua-icon
  {
-	color: <?php echo ($settings->bbn_icon_color=='') ? 'inherit' : "#".$settings->bbn_icon_color; ?>
+	color: <?php echo ($settings->bbn_icon_color=='') ? 'inherit' : bb_alerts_format_color( $settings->bbn_icon_color ); ?>
 }
 
 /* link color css */
@@ -47,7 +80,7 @@
 			break;
 		case 'alert-success' : echo "color: #3c763d";
 			break;
-		case 'alert-custom' : echo "color: #".$settings->bbn_font_color;
+		case 'alert-custom' : echo "color: ".bb_alerts_format_color( $settings->bbn_font_color );
 			break;
 	}?>
 }


### PR DESCRIPTION
## Summary

- Custom colors (font, background, border, icon, link) set via the color picker were ignored on the frontend — elements fell back to theme defaults
- Root cause: the CSS template hard-coded a `#` prefix on every color value, assuming a bare hex. The Beaver Builder color picker also stores `rgb()`/`rgba()` values (whenever a color is not fully opaque), producing invalid CSS such as `color: #rgb(233, 37, 37)` that browsers silently discard
- Fix: added a `bb_alerts_format_color()` helper that handles `rgb()`, `rgba()`, `#hex`, and bare hex values, and routed all five color outputs in `frontend.css.php` through it
- Legacy bare-hex values saved with older picker versions keep working unchanged
- Same fix pattern already shipped in the Bootstrap Cards plugin (`bb_cards_format_color()`)

## Test plan

- [x] `php -l` passes on the modified template
- [x] Functional render test of the CSS template with all four storage formats:
  - `rgb(233, 37, 37)` → emitted as-is
  - `rgba(20, 30, 40, 0.5)` → emitted as-is
  - bare hex `e92525` → `#e92525`
  - `#00ff00` → unchanged
  - no invalid `#rgb`/`#rgba` occurrences in output
- [ ] Manual: add an Alerts module with Custom notification type, set font/background/border/icon colors via the picker (including a non-opaque color), verify all render correctly on the frontend